### PR TITLE
Update Windows packaging copy command

### DIFF
--- a/.github/workflows/win-only.yml
+++ b/.github/workflows/win-only.yml
@@ -141,7 +141,8 @@ jobs:
         run: |
           $out = "dist"
           New-Item -ItemType Directory -Force -Path $out | Out-Null
-          Copy-Item -Recurse -Force (Split-Path "${{ steps.findexe.outputs.exe }}")"\*" $out\
+          $exeDir = Split-Path "${{ steps.findexe.outputs.exe }}"
+          Copy-Item -Recurse -Force -Path (Join-Path $exeDir '*') -Destination $out
           Compress-Archive -Path $out\* -DestinationPath input-leap-windows.zip
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- set the exe directory to a variable before packaging
- copy the entire executable directory into the dist folder using Join-Path

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfb384bc10832c968915a9650fe142